### PR TITLE
pass the AgentGroup parameter to installer

### DIFF
--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -60,7 +60,7 @@ if ($PackageParameters['AgentName']) {
 }
 
 if ($PackageParameters['AgentGroup']) {
-    $args = $args + " WAZUH_AGENT_GROUP=" + $PackageParameters['Group']
+    $args = $args + " WAZUH_AGENT_GROUP=" + $PackageParameters['AgentGroup']
 }
 
 Write-Output $args


### PR DESCRIPTION
minor bug: done some tests and figured out that the AgentGroup parameter value was not correctly passed to the wazuh-agent installer. 