### PR TITLE
Replace nuget itigo repo with chocowall

### DIFF
--- a/.github/workflows/chocomilk.yml
+++ b/.github/workflows/chocomilk.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"
           ANSIBLE_DEPRECATION_WARNINGS: "false"
-          CHOCOLATEY_ITIGO_API_KEY: ${{ secrets.CHOCOLATEY_ITIGO_API_KEY }}
+          CHOCOLATEY_CHOCOWALL_API_KEY: ${{ secrets.CHOCOLATEY_CHOCOWALL_API_KEY }}
           CHOCOLATEY_ORG_API_KEY: ${{ secrets.CHOCOLATEY_ORG_API_KEY }}
           MATTERMOST_API_KEY: ${{ secrets.MATTERMOST_API_KEY }}
           GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}

--- a/.milk.yml
+++ b/.milk.yml
@@ -29,8 +29,8 @@ deploy:
     repository: "https://push.chocolatey.org/"
     key: "{{ lookup('env','CHOCOLATEY_ORG_API_KEY') }}"
   - provider: chocolatey
-    repository: "https://nuget.itigo.tech/upload"
-    key: "{{ lookup('env','CHOCOLATEY_ITIGO_API_KEY') }}"
+    repository: "https://packages.ocrcl.ch/v3/index.json"
+    key: "{{ lookup('env','CHOCOLATEY_CHOCOWALL_API_KEY') }}"
   - provider: github
     name: "OpenCircle-Choco-Bot"
     email: "chocomilk@open-circle.ch"


### PR DESCRIPTION
Replace the decomissioned Nuget Itigo Repository with Chocowall.